### PR TITLE
Adding panic for container absent from context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Inversion Of Control Container
 
 [![GoDoc](https://godoc.org/github.com/renevo/ioc?status.svg)](https://godoc.org/github.com/renevo/ioc)
-[![Go Report Card](https://goreportcard.com/badge/github.com/renevo/ioc)](https://goreportcard.com/report/github.com/renevo/ioc) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/renevo/ioc)](https://goreportcard.com/report/github.com/renevo/ioc)
 [![Test](https://github.com/renevo/ioc/actions/workflows/test.yml/badge.svg)](https://github.com/renevo/ioc/actions/workflows/test.yml)
 
 This package provides a simple utility container for faciliting Inversion of Control software pattern. For clarity, this is not a dependency injection framework, merely a go routine safe container to share interfaces across an application.
@@ -19,8 +19,6 @@ This package contains no `init()` functions.
 ## Context Access
 
 Functions to interact with the container from `context.Context` are provided so that the container can be infered from a parent context. (see example).
-
-Given that a container is not available in the supplied context, the `ioc.FromContext` function will return the global `ioc.Container`.
 
 ## Custom Access
 

--- a/context.go
+++ b/context.go
@@ -1,6 +1,14 @@
 package ioc
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrContainerNotInContext is used when a container is not found in the context.
+	ErrContainerNotInContext = errors.New("container not found in context")
+)
 
 type contextKey string
 
@@ -15,33 +23,68 @@ func WithContext(ctx context.Context, container *Container) context.Context {
 func FromContext(ctx context.Context) *Container {
 	v := ctx.Value(iocContextKey)
 	if v == nil {
-		return global
+		return nil
 	}
 
 	return v.(*Container)
 }
 
 // RegisterToContext will register the supplied value of type T as the default value when using ResolveFromContext().
+//
+// This function will panic if the context does not contain a container.
 func RegisterToContext[T any](ctx context.Context, value T) {
-	(&GenericContainer[T]{Container: FromContext(ctx)}).Register(value)
+	container := FromContext(ctx)
+	if container == nil {
+		panic(ErrContainerNotInContext)
+	}
+
+	(&GenericContainer[T]{Container: container}).Register(value)
 }
 
 // RegisterNamedToContext will register the supplied value of type T with the specified name.
+//
+// This function will panic if the context does not contain a container.
 func RegisterNamedToContext[T any](ctx context.Context, name string, value T) {
-	(&GenericContainer[T]{Container: FromContext(ctx)}).RegisterNamed(name, value)
+	container := FromContext(ctx)
+	if container == nil {
+		panic(ErrContainerNotInContext)
+	}
+
+	(&GenericContainer[T]{Container: container}).RegisterNamed(name, value)
 }
 
 // ResolveFromContext will lookup the default registered value.
+//
+// This function will panic if the context does not contain a container.
 func ResolveFromContext[T any](ctx context.Context) (value T, found bool) {
-	return (&GenericContainer[T]{Container: FromContext(ctx)}).Resolve()
+	container := FromContext(ctx)
+	if container == nil {
+		panic(ErrContainerNotInContext)
+	}
+
+	return (&GenericContainer[T]{Container: container}).Resolve()
 }
 
 // ResolveNamedFromContext will lookup the value with the specified name.
+//
+// This function will panic if the context does not contain a container.
 func ResolveNamedFromContext[T any](ctx context.Context, name string) (value T, found bool) {
-	return (&GenericContainer[T]{Container: FromContext(ctx)}).ResolveNamed(name)
+	container := FromContext(ctx)
+	if container == nil {
+		panic(ErrContainerNotInContext)
+	}
+
+	return (&GenericContainer[T]{Container: container}).ResolveNamed(name)
 }
 
 // ResolveAllFromContext will lookup and return all values registered.
+//
+// This function will panic if the context does not contain a container.
 func ResolveAllFromContext[T any](ctx context.Context) (values []T) {
-	return (&GenericContainer[T]{Container: FromContext(ctx)}).ResolveAll()
+	container := FromContext(ctx)
+	if container == nil {
+		panic(ErrContainerNotInContext)
+	}
+
+	return (&GenericContainer[T]{Container: container}).ResolveAll()
 }


### PR DESCRIPTION
With the container not being present in a context, returning the global could result in a bad and confusion situation where the current context might not be rooted properly against the context the ioc was placed in. Rather than returning the global with no way of knowing, the application will now panic letting the developer know the context does not include a container (code bug)